### PR TITLE
[DOCS] Clarify docs for AuthorizedEvent

### DIFF
--- a/packages/jwt-auth/README.md
+++ b/packages/jwt-auth/README.md
@@ -41,7 +41,7 @@ function isTokenPayload(token: any): token is TokenPayload {
 }
 
 // This is your AWS handler
-const helloWorld = async (event: APIGatewayEvent& AuthorizedEvent<TokenPayload>) => {
+const helloWorld = async (event: APIGatewayEvent & AuthorizedEvent<TokenPayload>) => {
   // The middleware adds auth information if a valid token was added
   // If no auth was found and credentialsRequired is set to true, a 401 will be thrown. If auth exists you
   // have to check that it has the expected form.

--- a/packages/jwt-auth/README.md
+++ b/packages/jwt-auth/README.md
@@ -25,6 +25,7 @@ import {
 } from "@lambda-middleware/jwt-auth";
 import { compose } from "@lambda-middleware/compose";
 import { errorHandler } from "@lambda-middleware/http-error-handler";
+import { APIGatewayEvent } from 'aws-lambda'
 import createHttpError from "http-errors";
 
 interface TokenPayload {
@@ -40,7 +41,7 @@ function isTokenPayload(token: any): token is TokenPayload {
 }
 
 // This is your AWS handler
-const helloWorld = async (event: AuthorizedEvent<TokenPayload>) => {
+const helloWorld = async (event: APIGatewayEvent& AuthorizedEvent<TokenPayload>) => {
   // The middleware adds auth information if a valid token was added
   // If no auth was found and credentialsRequired is set to true, a 401 will be thrown. If auth exists you
   // have to check that it has the expected form.
@@ -71,7 +72,9 @@ export const handler = compose(
     algorithm: EncryptionAlgorithms.HS256,
     /** An optional boolean that enables making authorization mandatory */
     credentialsRequired: true,
-    /** An optional function that checks whether the token payload is formatted correctly */
+    /** An optional function that checks whether the token payload is formatted correctly.
+     * If you specify a TokenPayload type parameter to AuthorizedEvent, the corresponding type guard must be passed here.
+     */
     isPayload: isTokenPayload,
     /** A string or buffer containing either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA */
     secretOrPublicKey: "secret",


### PR DESCRIPTION
Adding this in reference to the [related issue](https://github.com/dbartholomae/middy-middleware-jwt-auth/issues/86) on the non-lambda version of the jwt middleware, hope that's ok!

- Add note about when `isPayload` is required. The invocation without it will not type check if AuthorizedEvent is parametrized with a TokenPayload, even if that type is empty
- Add APIGatewayEvent intersection type to the handler to clarify how other members on `event` can be accessed, given that AuthorizedEvent does not extend APIGatewayEvent (ordering APIGatewayEvent before AuthorizedEvent so that any members that override a previous definition would appear as such in the middleware chain -- that doesn't happen now, but it seems like a good practice for e.g. body parser)

<!-- Please only open PRs for issues in place. If there is no issue, please open the issue first. Then create this PR and link it to the issue by adding the issue number in the line below. -->
Closes #<!-- Replace this comment with the issue number -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

<!-- If you wrote meaningful commit messages, this is it. If you don't feel confident that your commit messages fully explain your changes and your reasoning behind it, then you can add more information to this PR. Or, even better, update your commit messages ;) -->
