### PR TITLE
feat: add easly accessable handler in order to make unit tests easier

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -57,6 +57,21 @@ export const handler: ProxyHandler = compose(
 )(helloWorld);
 ```
 
+## Unit tests
+
+In order to unit test handler without need of moving it outside of compose function you can access `handler` property of resulted function.
+```ts
+export const handle = composeHandler(
+  middleware1(),
+  middleware2(),
+  async (event) => {
+    // do some stuff...
+  },
+);
+
+handle.handler();
+```
+
 ## Usage in TypeScript strict mode
 
 There's a [known issue with TypeScript](https://github.com/microsoft/TypeScript/issues/29904) that pipe and compose functions cannot

--- a/packages/compose/src/compose-handler.ts
+++ b/packages/compose/src/compose-handler.ts
@@ -1,24 +1,24 @@
 import { compose } from "./compose";
 
-export function composeHandler<V, T1>(fn0: (x: V) => T1, handler: V): T1;
+export function composeHandler<V, T1>(fn0: (x: V) => T1, handler: V): T1 & { handler: V };;
 export function composeHandler<V, T1, T2>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T2;
+): T2 & { handler: V };
 export function composeHandler<V, T1, T2, T3>(
   fn2: (x: T2) => T3,
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T3;
+): T3 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4>(
   fn3: (x: T3) => T4,
   fn2: (x: T2) => T3,
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T4;
+): T4 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5>(
   fn4: (x: T4) => T5,
   fn3: (x: T3) => T4,
@@ -26,7 +26,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T5;
+): T5 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5, T6>(
   fn5: (x: T5) => T6,
   fn4: (x: T4) => T5,
@@ -35,7 +35,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T6;
+): T6 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7>(
   fn6: (x: T6) => T7,
   fn5: (x: T5) => T6,
@@ -45,7 +45,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T7;
+): T7 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8>(
   fn7: (x: T7) => T8,
   fn6: (x: T6) => T7,
@@ -56,7 +56,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T8;
+): T8 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
   fn8: (x: T8) => T9,
   fn7: (x: T7) => T8,
@@ -68,7 +68,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T9;
+): T9 & { handler: V };
 export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
   fn9: (x: T9) => T10,
   fn8: (x: T8) => T9,
@@ -81,7 +81,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
   fn1: (x: T1) => T2,
   fn0: (x: V) => T1,
   handler: V
-): T10;
+): T10 & { handler: V };
 export function composeHandler(...fns: Function[]): any {
   /* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */
   // @ts-ignore

--- a/packages/compose/src/compose-handler.ts
+++ b/packages/compose/src/compose-handler.ts
@@ -85,5 +85,7 @@ export function composeHandler<V, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 export function composeHandler(...fns: Function[]): any {
   /* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */
   // @ts-ignore
-  return compose(...fns.slice(0, fns.length - 1))(fns[fns.length - 1]);
+  const composed = compose(...fns.slice(0, fns.length - 1))(fns[fns.length - 1]);
+  composed.handler = fns[fns.length - 1];
+  return composed;
 }


### PR DESCRIPTION
<!-- Please only open PRs for issues in place. If there is no issue, please open the issue first. Then create this PR and link it to the issue by adding the issue number in the line below. -->
Closes #<!-- Replace this comment with the issue number -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.

<!-- If you wrote meaningful commit messages, this is it. If you don't feel confident that your commit messages fully explain your changes and your reasoning behind it, then you can add more information to this PR. Or, even better, update your commit messages ;) -->

Previously in order to unit test handler I had to put it outside of `composeHandler` and types were gone.
In order to make handler unit testable with fully working type system I assigned a variable to the function itself (not a common scenario) at the end of composeHandler.
